### PR TITLE
Add total amount and split percentage to memo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add your YNAB token and account names to a `config.yaml` file in the directory i
 
 ```yaml
 ynabToken: "<ynab token>"
-startDate: "<optional inclusive start date, e.g. '2021-02-23'>"
+startDate: "<optional inclusive start date, e.g. '2021-02-23' (useful if someone does a fresh start)>"
 
 firstAccount:
   budgetName: "<First person's budget name, e.g. '2020.1'>"

--- a/src/main/kotlin/co/moelten/splity/MirrorTransactions.kt
+++ b/src/main/kotlin/co/moelten/splity/MirrorTransactions.kt
@@ -268,6 +268,7 @@ fun getExtraDetailsForMemo(totalAmount: Long, paidAmount: Long): String {
 /** Convert a YNAB amount (int representing value * 1000) into a $X.XX string, avoiding precision loss */
 fun Long.toMoneyString() = "\$${"%,d".format(this / 1000)}.${"%02d".format((this / 10) % 100)}"
 
+/** Calculate this as a percentage of [total], represented as a double from 0-100 */
 fun Long.absolutePercentageOf(total: Long) = ((this * 100).toDouble() / total).absoluteValue
 
 /** Convert a percentage (double representing value in percent, i.e. 0-100) into a percentage string */

--- a/src/test/kotlin/co/moelten/splity/MirrorTransactionsTest.kt
+++ b/src/test/kotlin/co/moelten/splity/MirrorTransactionsTest.kt
@@ -229,7 +229,11 @@ internal class MirrorTransactionsTest {
       that(transactionList[0].importId).isEqualTo("splity:-350000:2020-02-06:1")
       that(transactionList[0].date).isEqualTo(manuallyAddedTransaction.date)
       that(transactionList[0].payeeName).isEqualTo(manuallyAddedTransaction.payeeName)
-      that(transactionList[0].memo).isEqualTo(manuallyAddedTransaction.memo)
+      that(transactionList[0].memo).isEqualTo(manuallyAddedTransaction.memo + """
+        
+        
+        Out of $350.00, you paid 100.0%
+      """.trimIndent())
       that(transactionList[0].cleared).isEqualTo(TransactionDetail.ClearedEnum.CLEARED)
       that(transactionList[0].approved).isFalse()
       that(transactionList[0].accountId).isEqualTo(TO_ACCOUNT_ID)
@@ -265,7 +269,11 @@ internal class MirrorTransactionsTest {
       that(transactionList[0].importId).isEqualTo("splity:${-transactionAddedFromTransfer.amount}:${transactionAddedFromTransfer.date}:1")
       that(transactionList[0].date).isEqualTo(transactionAddedFromTransfer.date)
       that(transactionList[0].payeeName).isEqualTo("Chicken Butt")
-      that(transactionList[0].memo).isEqualTo(transactionTransferNonSplitSource.memo)
+      that(transactionList[0].memo).isEqualTo(transactionTransferNonSplitSource.memo + """
+        
+        
+        Out of $10.00, you paid 100.0%
+      """.trimIndent())
       that(transactionList[0].cleared).isEqualTo(TransactionDetail.ClearedEnum.CLEARED)
       that(transactionList[0].approved).isFalse()
       that(transactionList[0].accountId).isEqualTo(TO_ACCOUNT_ID)
@@ -298,7 +306,11 @@ internal class MirrorTransactionsTest {
       that(transactionList[0].importId).isEqualTo("splity:${-transactionAddedFromTransfer.amount}:${transactionAddedFromTransfer.date}:1")
       that(transactionList[0].date).isEqualTo(transactionAddedFromTransfer.date)
       that(transactionList[0].payeeName).isEqualTo("Chicken Butt")
-      that(transactionList[0].memo).isEqualTo(transactionTransferNonSplitSource.memo)
+      that(transactionList[0].memo).isEqualTo(transactionTransferNonSplitSource.memo + """
+        
+        
+        Out of $10.00, you paid 100.0%
+      """.trimIndent())
       that(transactionList[0].cleared).isEqualTo(TransactionDetail.ClearedEnum.CLEARED)
       that(transactionList[0].approved).isFalse()
       that(transactionList[0].accountId).isEqualTo(TO_ACCOUNT_ID)
@@ -333,7 +345,11 @@ internal class MirrorTransactionsTest {
       that(transactionList[0].importId).isEqualTo("splity:${-transactionAddedFromTransfer.amount}:${transactionAddedFromTransfer.date}:1")
       that(transactionList[0].date).isEqualTo(transactionAddedFromTransfer.date)
       that(transactionList[0].payeeName).isEqualTo(transactionTransferSplitSource.payeeName)
-      that(transactionList[0].memo).isEqualTo(transactionTransferSplitSource.memo)
+      that(transactionList[0].memo).isEqualTo(transactionTransferSplitSource.memo + """
+
+
+        Out of $30.00, you paid 33.3%
+      """.trimIndent())
       that(transactionList[0].cleared).isEqualTo(TransactionDetail.ClearedEnum.CLEARED)
       that(transactionList[0].approved).isFalse()
       that(transactionList[0].accountId).isEqualTo(TO_ACCOUNT_ID)
@@ -378,7 +394,11 @@ internal class MirrorTransactionsTest {
       that(transactionList[0].importId).isEqualTo("splity:${-transactionAddedFromTransferWithLongId.amount}:${transactionAddedFromTransferWithLongId.date}:1")
       that(transactionList[0].date).isEqualTo(transactionAddedFromTransferWithLongId.date)
       that(transactionList[0].payeeName).isEqualTo(transactionTransferSplitSource.payeeName)
-      that(transactionList[0].memo).isEqualTo(transactionTransferSplitSource.memo)
+      that(transactionList[0].memo).isEqualTo(transactionTransferSplitSource.memo + """
+        
+        
+        Out of $30.00, you paid 33.3%
+      """.trimIndent())
       that(transactionList[0].cleared).isEqualTo(TransactionDetail.ClearedEnum.CLEARED)
       that(transactionList[0].approved).isFalse()
       that(transactionList[0].accountId).isEqualTo(TO_ACCOUNT_ID)


### PR DESCRIPTION
Now, memos on new split transactions will include the line e.g. "Out of $100.00, you paid 20%" after the given memo.

This won't affect the original transactions, since I don't think we're allowed to edit split transactions in the API still.