### PR TITLE
Hotfix: Don't clear transactions to avoid transaction update quirk

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
-enableFeaturePreview("VERSION_CATALOGS")
 rootProject.name = 'splity'
 include(':ynab-api')

--- a/src/main/kotlin/co/moelten/splity/database/ReplacedTransactionExtensions.kt
+++ b/src/main/kotlin/co/moelten/splity/database/ReplacedTransactionExtensions.kt
@@ -1,7 +1,6 @@
 package co.moelten.splity.database
 
 import co.moelten.splity.database.UpdateField.AMOUNT
-import co.moelten.splity.database.UpdateField.CLEAR
 import co.moelten.splity.database.UpdateField.DATE
 import co.moelten.splity.database.UpdateField.values
 import co.moelten.splity.models.PublicTransactionDetail
@@ -10,7 +9,6 @@ import com.ryanmoelter.ynab.ReplacedSubTransaction
 import com.ryanmoelter.ynab.ReplacedTransaction
 import com.ryanmoelter.ynab.StoredSubTransaction
 import com.ryanmoelter.ynab.StoredTransaction
-import com.youneedabudget.client.models.TransactionDetail
 
 fun StoredTransaction.toReplacedTransaction() = ReplacedTransaction(
   id = id,
@@ -64,14 +62,12 @@ fun PublicTransactionDetail.calculateUpdatedFieldsFrom(
   return values()
     .filter { updateField ->
       when (updateField) {
-        CLEAR -> approved && !replaced.approved // Newly approved -> clear complement
         AMOUNT -> amount != replaced.amount
         DATE -> date != replaced.date
       }
     }
     .filter { updateField ->
       complement == null || when (updateField) {
-        CLEAR -> complement.cleared != TransactionDetail.ClearedEnum.CLEARED
         AMOUNT -> complement.amount != -amount
         DATE -> complement.date != date
       }
@@ -80,5 +76,5 @@ fun PublicTransactionDetail.calculateUpdatedFieldsFrom(
 }
 
 enum class UpdateField(val shouldNotify: Boolean) {
-  CLEAR(false), AMOUNT(true), DATE(true),
+  AMOUNT(true), DATE(true),
 }

--- a/src/test/kotlin/co/moelten/splity/ActionApplierTest.kt
+++ b/src/test/kotlin/co/moelten/splity/ActionApplierTest.kt
@@ -1,8 +1,6 @@
 package co.moelten.splity
 
-import co.moelten.splity.database.ProcessedState.UPDATED
 import co.moelten.splity.database.ProcessedState.UP_TO_DATE
-import co.moelten.splity.database.UpdateField
 import co.moelten.splity.database.plus
 import co.moelten.splity.injection.createFakeSplityComponent
 import co.moelten.splity.test.Setup
@@ -10,7 +8,6 @@ import co.moelten.splity.test.addTransactions
 import co.moelten.splity.test.isComplementOf
 import co.moelten.splity.test.shouldContainSingleComplementOf
 import co.moelten.splity.test.shouldHaveAllTransactionsProcessed
-import co.moelten.splity.test.toApiTransaction
 import co.moelten.splity.test.toPublicTransactionDetail
 import co.moelten.splity.test.toPublicTransactionDetailList
 import com.ryanmoelter.ynab.database.Database
@@ -196,33 +193,5 @@ class ActionApplierTest : FunSpec({
       approved.shouldBeFalse()
       accountId shouldBe TO_ACCOUNT_ID.plainUuid
     }
-  }
-
-  test("update approved") {
-    setUpServerDatabase {
-      setUpBudgetsAndAccounts(fromBudget to listOf(FROM_ACCOUNT))
-      addTransactions(manuallyAddedTransaction())
-    }
-
-    setUpLocalDatabase {
-      addTransactions(
-        manuallyAddedTransaction(UP_TO_DATE),
-        manuallyAddedTransactionComplement(UPDATED)
-      )
-    }
-
-    actionApplier.applyActions(
-      TransactionAction.UpdateComplement(
-        fromTransaction = manuallyAddedTransactionComplement(UPDATED),
-        complement = manuallyAddedTransaction(),
-        updateFields = setOf(UpdateField.CLEAR),
-      )
-    )
-
-    serverDatabase.getTransactionById(manuallyAddedTransaction().id) shouldBe
-      manuallyAddedTransaction().copy(cleared = TransactionDetail.ClearedEnum.CLEARED)
-        .toApiTransaction()
-
-    localDatabase.shouldHaveAllTransactionsProcessed()
   }
 })

--- a/src/test/kotlin/co/moelten/splity/ActionCreatorTest.kt
+++ b/src/test/kotlin/co/moelten/splity/ActionCreatorTest.kt
@@ -1,15 +1,12 @@
 package co.moelten.splity
 
 import co.moelten.splity.database.ProcessedState.CREATED
-import co.moelten.splity.database.ProcessedState.UPDATED
 import co.moelten.splity.database.ProcessedState.UP_TO_DATE
-import co.moelten.splity.database.UpdateField
 import co.moelten.splity.database.plus
 import co.moelten.splity.database.replaceOnly
 import co.moelten.splity.database.toTransactionId
 import co.moelten.splity.injection.createFakeSplityComponent
 import co.moelten.splity.test.Setup
-import co.moelten.splity.test.addReplacedTransactions
 import co.moelten.splity.test.addTransactions
 import com.ryanmoelter.ynab.SyncData
 import com.ryanmoelter.ynab.database.Database
@@ -154,33 +151,6 @@ class ActionCreatorTest : FunSpec({
         TransactionAction.MarkProcessed(
           manuallyAddedTransaction(CREATED),
           manuallyAddedTransactionComplementWithoutImportId
-        )
-      )
-    }
-
-    test("clear transaction on complement approved") {
-      val manuallyAddedTransactionComplementApproved =
-        manuallyAddedTransactionComplement(UPDATED).copy(approved = true)
-      val existingManuallyAddedTransactionComplement =
-        manuallyAddedTransactionComplement(UP_TO_DATE)
-      val existingManuallyAddedTransaction =
-        manuallyAddedTransaction(UP_TO_DATE)
-
-      setUpLocalDatabase {
-        addReplacedTransactions(existingManuallyAddedTransactionComplement)
-        addTransactions(
-          manuallyAddedTransactionComplementApproved,
-          existingManuallyAddedTransaction
-        )
-      }
-
-      val actions = actionCreater.createDifferentialActionsForBothAccounts()
-
-      actions.shouldContainExactly(
-        TransactionAction.UpdateComplement(
-          fromTransaction = manuallyAddedTransactionComplementApproved,
-          complement = existingManuallyAddedTransaction,
-          updateFields = setOf(UpdateField.CLEAR),
         )
       )
     }

--- a/src/test/kotlin/co/moelten/splity/FakeYnabClient.kt
+++ b/src/test/kotlin/co/moelten/splity/FakeYnabClient.kt
@@ -3,7 +3,6 @@ package co.moelten.splity
 import co.moelten.splity.database.toAccountId
 import co.moelten.splity.database.toBudgetId
 import co.moelten.splity.database.toCategoryId
-import co.moelten.splity.database.toTransactionId
 import com.youneedabudget.client.MAX_IMPORT_ID_LENGTH
 import com.youneedabudget.client.YnabClient
 import com.youneedabudget.client.apis.AccountsApi
@@ -198,25 +197,26 @@ class FakeTransactions(
     transactionId: String,
     data: SaveTransactionWrapper
   ): TransactionResponse {
-    val isTransferFromSplit = (fakeYnabServerDatabase.getTransactionById(transactionId.toTransactionId())
-      ?: error("Cannot find transaction to update in server database with id $transactionId"))
-      .let { transaction ->
-        if (transaction.transferTransactionId != null) {
-          fakeYnabServerDatabase
-            .getTransactionsForAccount(transaction.accountId.toAccountId())
-            .any { transactions ->
-              transactions.subtransactions.any { subTransaction ->
-                subTransaction.id == transaction.transferTransactionId
-              }
-            }
-        } else {
-          false
-        }
-      }
-
-    assert(isTransferFromSplit) {
-      "Updating a transfer with a split source will cause them to silently break on the real API"
-    }
+    // TODO: Uncomment this
+//    val isTransferFromSplit = (fakeYnabServerDatabase.getTransactionById(transactionId.toTransactionId())
+//      ?: error("Cannot find transaction to update in server database with id $transactionId"))
+//      .let { transaction ->
+//        if (transaction.transferTransactionId != null) {
+//          fakeYnabServerDatabase
+//            .getTransactionsForAccount(transaction.accountId.toAccountId())
+//            .any { transactions ->
+//              transactions.subtransactions.any { subTransaction ->
+//                subTransaction.id == transaction.transferTransactionId
+//              }
+//            }
+//        } else {
+//          false
+//        }
+//      }
+//
+//    assert(isTransferFromSplit) {
+//      "Updating a transfer with a split source will cause them to silently break on the real API"
+//    }
 
     fakeYnabServerDatabase.budgetToAccountsMap
       .getValue(budgetId.toBudgetId())

--- a/src/test/kotlin/co/moelten/splity/FakeYnabClient.kt
+++ b/src/test/kotlin/co/moelten/splity/FakeYnabClient.kt
@@ -3,6 +3,7 @@ package co.moelten.splity
 import co.moelten.splity.database.toAccountId
 import co.moelten.splity.database.toBudgetId
 import co.moelten.splity.database.toCategoryId
+import co.moelten.splity.database.toTransactionId
 import com.youneedabudget.client.MAX_IMPORT_ID_LENGTH
 import com.youneedabudget.client.YnabClient
 import com.youneedabudget.client.apis.AccountsApi
@@ -106,7 +107,10 @@ class FakeTransactions(
     }
     val newTransactionDetail = data.transaction!!.toNewTransactionDetail()
     val accountId = data.transaction!!.accountId.toAccountId()
-    fakeYnabServerDatabase.addOrUpdateTransactionsForAccount(accountId, listOf(newTransactionDetail))
+    fakeYnabServerDatabase.addOrUpdateTransactionsForAccount(
+      accountId,
+      listOf(newTransactionDetail)
+    )
 
     return SaveTransactionsResponse(
       SaveTransactionsResponseData(
@@ -194,6 +198,26 @@ class FakeTransactions(
     transactionId: String,
     data: SaveTransactionWrapper
   ): TransactionResponse {
+    val isTransferFromSplit = (fakeYnabServerDatabase.getTransactionById(transactionId.toTransactionId())
+      ?: error("Cannot find transaction to update in server database with id $transactionId"))
+      .let { transaction ->
+        if (transaction.transferTransactionId != null) {
+          fakeYnabServerDatabase
+            .getTransactionsForAccount(transaction.accountId.toAccountId())
+            .any { transactions ->
+              transactions.subtransactions.any { subTransaction ->
+                subTransaction.id == transaction.transferTransactionId
+              }
+            }
+        } else {
+          false
+        }
+      }
+
+    assert(isTransferFromSplit) {
+      "Updating a transfer with a split source will cause them to silently break on the real API"
+    }
+
     fakeYnabServerDatabase.budgetToAccountsMap
       .getValue(budgetId.toBudgetId())
       .map { account -> account.id.toAccountId() } shouldContain

--- a/src/test/kotlin/co/moelten/splity/TransactionMirrorerTest.kt
+++ b/src/test/kotlin/co/moelten/splity/TransactionMirrorerTest.kt
@@ -777,9 +777,9 @@ internal class TransactionMirrorerTest : FunSpec({
           transactionAddedFromTransfer().copy(approved = false)
         )
       }
-      val beginningServerKnowledge = serverDatabase.currentServerKnowledge
 
       test("the unapproved transaction is ignored") {
+        val beginningServerKnowledge = serverDatabase.currentServerKnowledge
         transactionMirrorer.mirrorTransactions()
 
         withClue("Server knowledge should not change") {
@@ -819,7 +819,42 @@ internal class TransactionMirrorerTest : FunSpec({
           localDatabase.shouldHaveAllTransactionsProcessed()
         }
 
-        context("once the complement is approved") {
+        // TODO: Update the app to properly error on updates and do this
+        xcontext("when the complement is updated") {
+          transactionMirrorer.mirrorTransactions()
+          val existingComplement = serverDatabase.getTransactionsForAccount(TO_ACCOUNT_ID)
+            .find { it isComplementOf transactionAddedFromTransfer().toApiTransaction() }!!
+            .toPublicTransactionDetail(TO_BUDGET_ID, UPDATED)
+          val updatedComplement = existingComplement
+            .copy(amount = -15_000)
+          setUpServerDatabase {
+            addTransactions(updatedComplement)
+          }
+
+          test("the updated complement is marked as an error") {
+            transactionMirrorer.mirrorTransactions()
+
+            assertSoftly {
+              updatedComplement.thisOnServerShould(serverDatabase) {
+                flagColor shouldBe RED
+                approved.shouldBeFalse()
+                memo shouldBe "ERROR: Mirrors of transfers from split transactions can't be " +
+                  "updated, so the change has been undone. Change the mirror of this transaction " +
+                  "in the other budget instead. • " + existingComplement.memo
+
+                amount shouldBe existingComplement.amount
+                date shouldBe existingComplement.date
+                payeeName shouldBe existingComplement.payeeName
+                accountId shouldBe existingComplement.accountId.plainUuid
+                deleted.shouldBeFalse()
+              }
+              localDatabase.shouldMatchServer(serverDatabase)
+              localDatabase.shouldHaveAllTransactionsProcessed()
+            }
+          }
+        }
+
+        context("when the complement is approved") {
           transactionMirrorer.mirrorTransactions()
           setUpServerDatabase {
             addOrUpdateTransactionsForAccount(
@@ -832,22 +867,15 @@ internal class TransactionMirrorerTest : FunSpec({
             )
           }
 
-          test("the original transaction is cleared") {
+          test("nothing happens") {
+            val beginningServerKnowledge = serverDatabase.currentServerKnowledge
             transactionMirrorer.mirrorTransactions()
 
-            transactionAddedFromTransfer().thisOnServerShould(serverDatabase) {
-              cleared shouldBe CLEARED
-
-              amount shouldBe transactionAddedFromTransfer().amount
-              date shouldBe transactionAddedFromTransfer().date
-              payeeName shouldBe transactionAddedFromTransfer().payeeName
-              memo shouldBe transactionAddedFromTransfer().memo
-              approved.shouldBeTrue()
-              deleted.shouldBeFalse()
-              accountId shouldBe transactionAddedFromTransfer().accountId.plainUuid
+            withClue("Server knowledge should not change") {
+              serverDatabase.currentServerKnowledge shouldBe beginningServerKnowledge
             }
-            localDatabase.shouldMatchServer(serverDatabase)
             localDatabase.shouldHaveAllTransactionsProcessed()
+            localDatabase.shouldMatchServer(serverDatabase)
           }
         }
       }
@@ -1067,7 +1095,7 @@ private suspend fun FunSpecContainerScope.simpleCreatedTransactionsShouldMirrorP
 
         context("with a red-flagged update") {
           val oldManualTransaction = manuallyAddedTransaction(UP_TO_DATE)
-            .copy(approved = false)
+            .copy(amount = 200_000)
 
           setUpLocalDatabase {
             addTransactions(oldManualTransaction)
@@ -1076,16 +1104,22 @@ private suspend fun FunSpecContainerScope.simpleCreatedTransactionsShouldMirrorP
           test("mirrorTransactions doesn't duplicate the transaction") {
             transactionMirrorer.mirrorTransactions()
 
-            serverDatabase.getTransactionsForAccount(FROM_ACCOUNT_ID)
-              .shouldContain(redFlaggedTransaction.toApiTransaction())
-            serverDatabase.getTransactionsForAccount(TO_ACCOUNT_ID)
-              .toPublicTransactionDetailList(TO_BUDGET_ID, UP_TO_DATE)
-              .shouldNotContainComplementOf(redFlaggedTransaction)
-            localDatabase.getAllReplacedTransactions().shouldContainExactly(oldManualTransaction)
-            localDatabase.getAllTransactions()
-              .shouldContain(redFlaggedTransaction.copy(processedState = UPDATED))
-            localDatabase.getAllTransactions()
-              .shouldNotContainComplementOf(redFlaggedTransaction)
+            withClue("Server transactions") {
+              serverDatabase.getTransactionsForAccount(FROM_ACCOUNT_ID)
+                .shouldContain(redFlaggedTransaction.toApiTransaction())
+              serverDatabase.getTransactionsForAccount(TO_ACCOUNT_ID)
+                .toPublicTransactionDetailList(TO_BUDGET_ID, UP_TO_DATE)
+                .shouldNotContainComplementOf(redFlaggedTransaction)
+            }
+            withClue("Replaced transactions") {
+              localDatabase.getAllReplacedTransactions().shouldContainExactly(oldManualTransaction)
+            }
+            withClue("All transactions transactions") {
+              localDatabase.getAllTransactions()
+                .shouldContain(redFlaggedTransaction.copy(processedState = UPDATED))
+              localDatabase.getAllTransactions()
+                .shouldNotContainComplementOf(redFlaggedTransaction)
+            }
           }
         }
       }

--- a/src/test/kotlin/co/moelten/splity/TransactionMirrorerTest.kt
+++ b/src/test/kotlin/co/moelten/splity/TransactionMirrorerTest.kt
@@ -819,7 +819,7 @@ internal class TransactionMirrorerTest : FunSpec({
           localDatabase.shouldHaveAllTransactionsProcessed()
         }
 
-        // TODO: Update the app to properly error on updates and do this
+        // TODO: Update the app to properly error on updates and unignore this
         xcontext("when the complement is updated") {
           transactionMirrorer.mirrorTransactions()
           val existingComplement = serverDatabase.getTransactionsForAccount(TO_ACCOUNT_ID)


### PR DESCRIPTION
We can't update a transfer of a split transaction through the api without breaking the transfer link for some reason.