### PR TITLE
Properly mirror memo of split transaction

### DIFF
--- a/src/main/kotlin/co/moelten/splity/YnabExtensions.kt
+++ b/src/main/kotlin/co/moelten/splity/YnabExtensions.kt
@@ -9,12 +9,12 @@ import com.youneedabudget.client.models.TransactionDetail
 import kotlin.math.absoluteValue
 
 data class AccountAndBudget(val accountId: AccountId, val accountPayeeId: PayeeId, val budgetId: BudgetId)
-data class TransactionDescription(val payeeName: String?, val memo: String?, val totalAmount: Long)
+data class TransactionDescription(val payeeName: String?, val memo: String, val totalAmount: Long)
 
 val PublicTransactionDetail.transactionDescription
   get() = TransactionDescription(
     payeeName = payeeName,
-    memo = memo,
+    memo = memo.orEmpty(),
     totalAmount = amount
   )
 

--- a/src/main/kotlin/co/moelten/splity/database/Repository.kt
+++ b/src/main/kotlin/co/moelten/splity/database/Repository.kt
@@ -110,13 +110,13 @@ class Repository(
     )
   }
 
-  fun getSubTransactionsByTransferTransactionId(
+  fun getSubTransactionByTransferId(
     transferId: TransactionId
   ): PublicSubTransaction? {
-    return database.storedSubTransactionQueries
-      .getById(transferId.string.toSubTransactionId())
+    val storedSubTransaction = database.storedSubTransactionQueries
+      .getByTransferId(transferId)
       .executeAsOneOrNull()
-      ?.toPublicSubTransaction()
+    return storedSubTransaction?.toPublicSubTransaction()
   }
 
   fun getTransactionBySubTransactionTransferId(

--- a/src/main/sqldelight/com/ryanmoelter/ynab/StoredSubTransaction.sq
+++ b/src/main/sqldelight/com/ryanmoelter/ynab/StoredSubTransaction.sq
@@ -42,6 +42,12 @@ FROM storedSubTransaction
 WHERE transactionId = ?
 ;
 
+getByTransferId:
+SELECT *
+FROM storedSubTransaction
+WHERE transferTransactionId = ?
+;
+
 getByAccount:
 SELECT *
 FROM storedSubTransaction

--- a/src/test/kotlin/co/moelten/splity/ActionApplierTest.kt
+++ b/src/test/kotlin/co/moelten/splity/ActionApplierTest.kt
@@ -155,7 +155,7 @@ class ActionApplierTest : FunSpec({
       }:1"
       date shouldBe transactionAddedFromTransfer(isFromSplitSource = true).date
       payeeName shouldBe transactionTransferSplitSource().payeeName
-      memo shouldBe transactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
+      memo shouldBe subTransactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
       cleared shouldBe TransactionDetail.ClearedEnum.CLEARED
       approved.shouldBeFalse()
       deleted.shouldBeFalse()
@@ -201,7 +201,7 @@ class ActionApplierTest : FunSpec({
       importId shouldBe "splity:${-transactionAddedFromTransferWithLongId.amount}:${transactionAddedFromTransferWithLongId.date}:1"
       date shouldBe transactionAddedFromTransferWithLongId.date
       payeeName shouldBe transactionTransferSplitSource().payeeName
-      memo shouldBe transactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
+      memo shouldBe subTransactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
       cleared shouldBe TransactionDetail.ClearedEnum.CLEARED
       approved.shouldBeFalse()
       accountId shouldBe TO_ACCOUNT_ID.plainUuid

--- a/src/test/kotlin/co/moelten/splity/FakeYnabClient.kt
+++ b/src/test/kotlin/co/moelten/splity/FakeYnabClient.kt
@@ -368,7 +368,7 @@ fun SaveTransaction.toNewTransactionDetail(
   approved = approved ?: false,
   accountId = accountId,
   deleted = false,
-  accountName = oldTransaction?.accountName ?: "",
+  accountName = oldTransaction?.accountName.orEmpty(),
   subtransactions = if (subtransactions.isNullOrEmpty()) {
     emptyList()
   } else {
@@ -383,7 +383,7 @@ fun SaveTransaction.toNewTransactionDetail(
   matchedTransactionId = null,
   importId = importId,
   payeeName = payeeName ?: oldTransaction?.payeeName,
-  categoryName = oldTransaction?.categoryName ?: ""
+  categoryName = oldTransaction?.categoryName.orEmpty()
 )
 
 fun SaveSubTransaction.toNewSubTransaction(

--- a/src/test/kotlin/co/moelten/splity/TransactionMirrorerTest.kt
+++ b/src/test/kotlin/co/moelten/splity/TransactionMirrorerTest.kt
@@ -815,7 +815,7 @@ internal class TransactionMirrorerTest : FunSpec({
             importId shouldBe "splity:-10000:2020-02-07:1"
             date shouldBe transactionAddedFromTransfer(isFromSplitSource = true).date
             payeeName shouldBe transactionTransferSplitSource().payeeName
-            memo shouldBe transactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
+            memo shouldBe subTransactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
             cleared shouldBe CLEARED
             deleted.shouldBeFalse()
             accountId shouldBe TO_ACCOUNT_ID.plainUuid
@@ -989,7 +989,7 @@ private suspend fun FunSpecContainerScope.simpleCreatedTransactionsShouldMirrorP
           }:1"
           date shouldBe transactionAddedFromTransfer(isFromSplitSource = true).date
           payeeName shouldBe transactionTransferSplitSource().payeeName
-          memo shouldBe transactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
+          memo shouldBe subTransactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
           cleared shouldBe CLEARED
           approved.shouldBeFalse()
           deleted.shouldBeFalse()
@@ -1039,7 +1039,7 @@ private suspend fun FunSpecContainerScope.simpleCreatedTransactionsShouldMirrorP
           }:1"
           date shouldBe transactionAddedFromTransferWithLongId.date
           payeeName shouldBe transactionTransferSplitSource().payeeName
-          memo shouldBe transactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
+          memo shouldBe subTransactionTransferSplitSource().memo + " • Out of $30.00, you paid 33.3%"
           cleared shouldBe CLEARED
           approved.shouldBeFalse()
           deleted.shouldBeFalse()


### PR DESCRIPTION
For example, a transaction labeled "Rent and utilities" with splits of "Rent" and "Utilities" used to each be mirrored as "Rent and utilities". They will now be mirrored properly as "Rent" and "Utilities" separately.