### PR TITLE
Update renovate config with dependency cooldowns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    steps:      
+    steps:
     - uses: actions/checkout@v4.3.1
     - name: Set up our JDK environment
       uses: actions/setup-java@v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version-file: '.sdkmanrc'
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v3.5.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-java@v5.2.0
       with:
         distribution: 'zulu'
-        java-version: '25'
+        java-version-file: '.sdkmanrc'
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v3.5.0
       with:
@@ -31,4 +31,4 @@ jobs:
           LICENSE.txt
           build/distributions/*.tar
           build/distributions/*.zip
-    
+

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ],
-  "schedule": "every weekend",
+  "schedule": [
+    "every weekend"
+  ],
   "timezone": "America/Los_Angeles",
   "labels": [
     "dependencies"
@@ -12,7 +14,24 @@
     "ryanmoelter"
   ],
   "prHourlyLimit": 0,
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "Patch dependency updates",
+      "automerge": true
+    },
     {
       "matchPackageNames": [
         "org.jetbrains.kotlin.jvm",
@@ -23,35 +42,6 @@
       ],
       "groupName": "Kotlin and dependencies",
       "automerge": false
-    },
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "pin",
-        "digest"
-      ],
-      "excludePackageNames": [
-        "org.jetbrains.kotlin.jvm",
-        "com.google.devtools.ksp",
-        "org.jetbrains.kotlin:kotlin-stdlib",
-        "org.jetbrains.kotlin.plugin.serialization",
-        "org.jetbrains.kotlin:kotlin-reflect"
-      ],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "excludePackageNames": [
-        "org.jetbrains.kotlin.jvm",
-        "com.google.devtools.ksp",
-        "org.jetbrains.kotlin:kotlin-stdlib",
-        "org.jetbrains.kotlin.plugin.serialization",
-        "org.jetbrains.kotlin:kotlin-reflect"
-      ],
-      "groupName": "Patch dependency updates",
-      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
- Use dependency cooldowns to mitigate supply chain attacks
- Use best-practices config base
- Use `.sdkmanrc` file for github actions java versions